### PR TITLE
Decrease dashboard SSL cert validity to 1 year

### DIFF
--- a/src/scripts/master.sh
+++ b/src/scripts/master.sh
@@ -35,7 +35,7 @@ fi
 # deploy dashboard
 mkdir /home/vagrant/certs
 openssl genrsa -out /home/vagrant/certs/dashboard.key 2048
-openssl req -x509 -new -nodes -key /home/vagrant/certs/dashboard.key -subj "/CN=k8s.local" -days 3650 -out /home/vagrant/certs/dashboard.crt
+openssl req -x509 -new -nodes -key /home/vagrant/certs/dashboard.key -subj "/CN=k8s.local" -days 365 -out /home/vagrant/certs/dashboard.crt
 kubectl create secret generic kubernetes-dashboard-certs --from-file=tls.crt=/home/vagrant/certs/dashboard.crt --from-file=tls.key=/home/vagrant/certs/dashboard.key --namespace kube-system
 kubectl apply -f /src/manifests/dashboard/
 kubectl apply -f /src/manifests/rbac/rbac.yaml


### PR DESCRIPTION
Decrease dashboard SSL cert validity to 1 year since macOS Catalina added some restrictions - https://support.apple.com/en-us/HT210176.
This way k8s dashboard can also be accessed using chrome.