### PR TITLE
Fix permissions and env path

### DIFF
--- a/docs/cloud-prerequisites.md
+++ b/docs/cloud-prerequisites.md
@@ -12,7 +12,7 @@ Also you need internet connectivity and *be able to access the internet on the f
 - TCP/22
 
 You can use http://portquiz.net:<port number> for testing the egress
-  
+
 Example: http://portquiz.net:30080 tests if 30080/TCP port is opened for egress.
 To verify, go to command line and execute:
 
@@ -23,7 +23,7 @@ Your IP: 188.25.190.205
 ```
 Do the same for the remaining ports from the above mentioned port list.
 
-  
+
 a) Download and install (with default settings) the following software (64bit
 version):
 
@@ -73,6 +73,6 @@ git clone https://github.com/hlesey/phippy.git
 e) Configure `kubectl` command line tool. The following script needs be executed from `labs` folder:
 `./kubeadm-vagrant/src/utils/tools/configure-kubectl.sh`.
 
-After that, run the following command to load the new shell configuration: `source ~/.bash_profile`
+After that, run the following command to load the new shell configuration: `source ~/.bash_profile` (MacOS or Windows) or `source ~/.profile` (Linux)
 
 If everything went smooth, you should be ready for the trip :) !

--- a/src/utils/tools/configure-kubectl.sh
+++ b/src/utils/tools/configure-kubectl.sh
@@ -4,6 +4,7 @@ WINDOWS="MINGW64_NT"
 MAC="Darwin"
 
 extension=""
+env_path="$HOME/.bash_profile"
 
 if [[ $(uname | grep $WINDOWS) != "" ]]; then
     os="windows"
@@ -12,6 +13,9 @@ elif [[ $(uname| grep $MAC) != "" ]]; then
 	os="mac"
 else
 	os="linux"
+	# If bash is not opened with interactive login, .bash_profile won't be loaded
+	# See https://askubuntu.com/a/121075 for a good explanation
+	env_path="$HOME/.profile"
 fi
 
 echo "Detected $os operating system."
@@ -19,8 +23,9 @@ echo "Detected $os operating system."
 mkdir -p bin
 curl -o bin/kubectl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/$os/amd64/kubectl${extension}"
 curl -o bin/kubetail -LO https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
+chmod +x bin/kube*
 
-cat <<EOF >> ~/.bash_profile
+cat <<EOF >> "${env_path}"
 export PATH="$PATH:$(pwd)/bin"
 export KUBECONFIG="$(pwd)/kubeadm-vagrant/src/output/kubeconfig.yaml:$(pwd)/config/kubeconfig.yaml"
 alias kns='kubectl config set-context \$(kubectl config current-context) --namespace'


### PR DESCRIPTION
Resolves https://github.com/hlesey/kubeadm-vagrant/issues/41

It also stores exports and aliases in `"$HOME/.profile"` for linux systems. See https://askubuntu.com/a/121075 for a good explanation 