### PR TITLE
Add nginx as default ingress class

### DIFF
--- a/src/manifests/dashboard/dashboard-ingress.yml
+++ b/src/manifests/dashboard/dashboard-ingress.yml
@@ -8,7 +8,6 @@ metadata:
   name: dashboard-ingress
   namespace: kube-system
 spec:
-  ingressClassName: nginx
   tls:
   - hosts:
     - clusterx.qedzone.ro

--- a/src/manifests/ingress/nginx/nginx.yaml
+++ b/src/manifests/ingress/nginx/nginx.yaml
@@ -338,6 +338,7 @@ spec:
             - --validating-webhook=:8443
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
+            - --watch-ingress-without-class=true
           securityContext:
             capabilities:
               drop:
@@ -417,6 +418,8 @@ metadata:
     app.kubernetes.io/version: 1.1.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
   name: nginx
   namespace: ingress-nginx
 spec:

--- a/src/manifests/network/cilium/hubble-ui-ingress.yml
+++ b/src/manifests/network/cilium/hubble-ui-ingress.yml
@@ -5,7 +5,6 @@ metadata:
   name: hubble-ui
   namespace: kube-system
 spec:
-  ingressClassName: nginx
   rules:
   - host: hubble-ui.clusterx.qedzone.ro
     http:


### PR DESCRIPTION
Instead of explicitly specifying `ingressClassName` for every `Ingress` object, we can set nginx as the default ingress class and all ingress objects will be handled by nginx ingress class if not explicitly specified otherwise..