### PR TITLE
Update ubuntu version for docker and k8s-empty

### DIFF
--- a/src/aws/docker/dockerhost_module/variables.tf
+++ b/src/aws/docker/dockerhost_module/variables.tf
@@ -22,7 +22,7 @@ variable "az" {
 }
 
 variable "instance-ami" {
-  default     = "ami-0c259a97cbf621daf"
+  default     = "ami-08ca3fed11864d6bb" # Ubuntu Focal 20.04 LTS
   description = "Which ami is used"
 }
 

--- a/src/aws/k8s-empty/k8s_module/main.tf
+++ b/src/aws/k8s-empty/k8s_module/main.tf
@@ -110,7 +110,7 @@ resource "aws_instance" "control-plane" {
   }
 
   provisioner "file" {
-    source      = "../../../../k8s-labs/src/kubeadm/src/aws/manifests"
+    source      = "../../../../k8s-labs/src/kubeadm/src/manifests/aws"
     destination = "/src/"
   }
 }

--- a/src/aws/k8s-empty/k8s_module/variables.tf
+++ b/src/aws/k8s-empty/k8s_module/variables.tf
@@ -17,7 +17,7 @@ variable "az" {
 }
 
 variable "instance-ami" {
-  default     = "ami-0c259a97cbf621daf"
+  default     = "ami-08ca3fed11864d6bb" # Ubuntu Focal 20.04 LTS
   description = "Which ami is used"
 }
 


### PR DESCRIPTION
Update ubuntu version to focal for docker/k8s-empty aws.
Update flannel path for kubeadm lab: https://github.com/hlesey/k8s-labs/pull/18