### PR TITLE
Fix apt install noninteractive mode

### DIFF
--- a/deploy/aws/k8s/k8s_module/main.tf
+++ b/deploy/aws/k8s/k8s_module/main.tf
@@ -124,7 +124,7 @@ resource "aws_instance" "control-plane" {
 }
 
 resource "aws_eip" "control-plane" {
-  vpc        = true
+  domain     = "vpc"
   instance   = aws_instance.control-plane.id
   depends_on = [aws_internet_gateway.gw]
   tags = {

--- a/deploy/aws/k8s/main.tf
+++ b/deploy/aws/k8s/main.tf
@@ -6,62 +6,62 @@ locals {
   # adjust cluster lists based on your needs
   clusters = {
     cluster0 = {
-      allowed_cidr_blocks = "193.105.140.131/32",
+      allowed_cidr_blocks = "0.0.0.0/0",
     },
-#    cluster1 = {
-#      allowed_cidr_blocks = "0.0.0.0/0",
-#    },
-#     cluster2 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster3 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster4 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster5 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster6 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster7 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster8 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster9 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster10 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster11 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster12 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster13 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster14 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster15 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster16 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster17 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
-#     cluster18 = {
-#       allowed_cidr_blocks = "0.0.0.0/0",
-#     },
+    cluster1 = {
+      allowed_cidr_blocks = "0.0.0.0/0",
+    },
+    # cluster2 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster3 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster4 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster5 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster6 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster7 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster8 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster9 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster10 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster11 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster12 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster13 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster14 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster15 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster16 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster17 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
+    # cluster18 = {
+    #   allowed_cidr_blocks = "0.0.0.0/0",
+    # },
     # cluster19 = {
     #   allowed_cidr_blocks = "0.0.0.0/0",
     # },

--- a/deploy/aws/k8s/main.tf
+++ b/deploy/aws/k8s/main.tf
@@ -6,62 +6,62 @@ locals {
   # adjust cluster lists based on your needs
   clusters = {
     cluster0 = {
-      allowed_cidr_blocks = "0.0.0.0/0",
+      allowed_cidr_blocks = "193.105.140.131/32",
     },
-    cluster1 = {
-      allowed_cidr_blocks = "0.0.0.0/0",
-    },
-    # cluster2 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster3 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster4 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster5 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster6 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster7 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster8 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster9 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster10 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster11 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster12 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster13 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster14 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster15 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster16 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster17 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
-    # cluster18 = {
-    #   allowed_cidr_blocks = "0.0.0.0/0",
-    # },
+#    cluster1 = {
+#      allowed_cidr_blocks = "0.0.0.0/0",
+#    },
+#     cluster2 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster3 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster4 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster5 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster6 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster7 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster8 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster9 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster10 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster11 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster12 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster13 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster14 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster15 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster16 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster17 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
+#     cluster18 = {
+#       allowed_cidr_blocks = "0.0.0.0/0",
+#     },
     # cluster19 = {
     #   allowed_cidr_blocks = "0.0.0.0/0",
     # },

--- a/src/scripts/common.sh
+++ b/src/scripts/common.sh
@@ -6,7 +6,7 @@ set -xe
 
 # load variables
 source /src/scripts/envs
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 
 # add control-plane IP to hosts file
 echo "${CONTROL_PLANE_IP} control-plane control-plane.local nfsserver.local" >> /etc/hosts
@@ -37,7 +37,7 @@ fi
 
 # install dependencies
 apt-get update > /dev/null
-apt-get install -y iptables arptables ebtables nfs-kernel-server nfs-common apt-transport-https ntp \
+yes | apt-get install -yq iptables arptables ebtables nfs-kernel-server nfs-common apt-transport-https ntp \
                    telnet jq dos2unix ca-certificates curl gnupg lsb-release > /dev/null
 
 # Install CRI-O
@@ -51,7 +51,7 @@ curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/
 curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/"${CRIO_VERSION}"/"${OS}"/Release.key | gpg --dearmor -o /usr/share/keyrings/libcontainers-crio-archive-keyring.gpg
 
 apt-get update > /dev/null
-apt-get install -y cri-o cri-o-runc cri-tools > /dev/null
+yes | apt-get install -yq cri-o cri-o-runc cri-tools > /dev/null
 
 # setup cri-o
 systemctl daemon-reload
@@ -69,7 +69,7 @@ EOF
 
 # install kubeadm
 sudo apt-get update > /dev/null
-apt-get install -y kubeadm="${K8S_VERSION}-00" kubelet="${K8S_VERSION}-00" kubectl="${K8S_VERSION}-00" > /dev/null
+yes | apt-get install -yq kubeadm="${K8S_VERSION}-00" kubelet="${K8S_VERSION}-00" kubectl="${K8S_VERSION}-00" > /dev/null
 
 # Install kubetail
 curl -s https://raw.githubusercontent.com/johanhaleby/kubetail/control-plane/kubetail --output /usr/local/bin/kubetail


### PR DESCRIPTION
Fix apt install noninteractive mode. Currently the bootstrap script `common.sh` was hung because it was expecting a user confirmation.

This PR also address the `aws_eip` terraform resource warning by switching to `domain     = "vpc"`