### PR TITLE
Make deployment multi az

### DIFF
--- a/deploy/aws/Readme.md
+++ b/deploy/aws/Readme.md
@@ -48,7 +48,7 @@ Maybe do a backup first.
 ```terraform
 terraform plan -target=module.clusters[\"cluster11\"]
 terraform apply -target=module.clusters[\"cluster11\"]
-terraform destroy -target=module.clusters[\"cluster11\"]
+terraform destroy -target=module.clusters[\"cluster10\"] -target=module.clusters[\"cluster11\"]
 ```
 
 ```terraform

--- a/deploy/aws/k8s-empty/main.tf
+++ b/deploy/aws/k8s-empty/main.tf
@@ -3,6 +3,7 @@ provider "aws" {
 }
 
 locals {
+  az_list = ["a", "b", "c"]
   # adjust cluster lists based on your needs
   clusters = {
     cluster-empty0 = {
@@ -81,7 +82,7 @@ module "clusters" {
   source       = "./k8s_module"
   cluster-name = each.key
 
-  az                  = var.az
+  az                  = local.az_list[tonumber(substr(each.key, 13, 2)) % 3]
   region              = var.region
   allowed-cidr-blocks = each.value.allowed_cidr_blocks
 

--- a/deploy/aws/k8s/k8s_module/main.tf
+++ b/deploy/aws/k8s/k8s_module/main.tf
@@ -209,10 +209,6 @@ resource "aws_instance" "node" {
   availability_zone           = "${var.region}${var.az}"
   ami                         = var.instance-ami
   instance_type               = var.node-instance-type
-  root_block_device {
-      volume_size = "${var.node-disk-size}"
-      volume_type = "gp3"
-    }
   ebs_optimized = true
   key_name                    = var.ssh-key-name
   subnet_id                   = aws_subnet.main.id

--- a/deploy/aws/k8s/k8s_module/variables.tf
+++ b/deploy/aws/k8s/k8s_module/variables.tf
@@ -19,7 +19,7 @@ variable "az" {
 variable "instance-ami" {
   # Get new AMI from https://cloud-images.ubuntu.com/locator/ec2/
   default     = "ami-02fd062ee104754fc" # Ubuntu Noble Numbat	24.04 LTS for eu-west-1 region, arm64 arch and 	hvm:ebs-ssd-gp3 instance type
-              # "ami-0a5fc7f536cbd4467" equivalient for eu-west-2
+              # "ami-0a5fc7f536cbd4467" equivalent for eu-west-2
   description = "Which ami is used"
 }
 

--- a/deploy/aws/k8s/k8s_module/variables.tf
+++ b/deploy/aws/k8s/k8s_module/variables.tf
@@ -19,6 +19,7 @@ variable "az" {
 variable "instance-ami" {
   # Get new AMI from https://cloud-images.ubuntu.com/locator/ec2/
   default     = "ami-02fd062ee104754fc" # Ubuntu Noble Numbat	24.04 LTS for eu-west-1 region, arm64 arch and 	hvm:ebs-ssd-gp3 instance type
+              # "ami-0a5fc7f536cbd4467" equivalient for eu-west-2
   description = "Which ami is used"
 }
 
@@ -30,11 +31,6 @@ variable "control-plane-instance-type" {
 variable "node-instance-type" {
   default     = "t4g.small"
   description = "Which EC2 instance type to use for the worker nodes"
-}
-
-variable "node-disk-size" {
-  default = 20
-  description = "Size of the disk in GB"
 }
 
 variable "ssh-key-path" {

--- a/deploy/aws/k8s/main.tf
+++ b/deploy/aws/k8s/main.tf
@@ -3,6 +3,8 @@ provider "aws" {
 }
 
 locals {
+  az_list = ["a", "b", "c"]
+
   # adjust cluster lists based on your needs
   clusters = {
     cluster0 = {
@@ -81,7 +83,7 @@ module "clusters" {
   source       = "./k8s_module"
   cluster-name = each.key
 
-  az                  = var.az
+  az                  = local.az_list[tonumber(substr(each.key, 7, 2)) % 3]
   region              = var.region
   allowed-cidr-blocks = each.value.allowed_cidr_blocks
 


### PR DESCRIPTION
- Make each cluster be deployed in different AZs, round-robbin
- Remove the disk setup for root as it is not used. The partition should be increase at bootstrap with another script. For the moment we are good with the default size. 