### PR TITLE
Expose envoy gateway via envoyproxy object runnig in host network

### DIFF
--- a/infra/aws/k8s/k8s_module/main.tf
+++ b/infra/aws/k8s/k8s_module/main.tf
@@ -83,6 +83,24 @@ resource "aws_security_group_rule" "allow_k8sapi_from_admin" {
   security_group_id = aws_security_group.kubernetes.id
 }
 
+resource "aws_security_group_rule" "allow_http_from_internet" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = split(",", var.allowed-cidr-blocks)
+  security_group_id = aws_security_group.kubernetes.id
+}
+
+resource "aws_security_group_rule" "allow_https_from_internet" {
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = split(",", var.allowed-cidr-blocks)
+  security_group_id = aws_security_group.kubernetes.id
+}
+
 resource "aws_security_group_rule" "allow_nodeport_from_internet" {
   type              = "ingress"
   from_port         = 30000

--- a/src/addons/envoy-gateway/custom.yaml
+++ b/src/addons/envoy-gateway/custom.yaml
@@ -1,9 +1,58 @@
+---
+apiVersion: config.gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: host-port-config
+  namespace: envoy-gateway
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 1 # Scale based on available control plane nodes
+        container:
+          ports:
+          - name: http
+            containerPort: 8080
+            hostPort: 80 # Binds to Node Public IP port 80
+          - name: https
+            containerPort: 8443
+            hostPort: 443 # Binds to Node Public IP port 443
+          # Needed if using ports < 1024 on some K8s distributions
+          securityContext:
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+        pod:
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: "true"
+          tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+            effect: NoSchedule
+          # REQUIRED: Prevents 2 pods from landing on 1 node (Port Conflict)
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    # Matches the label Envoy Gateway adds to its managed proxy pods
+                    gateway.envoyproxy.io/owning-gateway-name: public-gateway
+                topologyKey: "kubernetes.io/hostname"
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: envoy-gateway
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: config.gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: host-port-config
+    namespace: envoy-gateway
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -32,22 +81,3 @@ spec:
         certificateRefs:
         - kind: Secret
           name: envoy-gateway
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: envoy-gateway-external-service
-  namespace: envoy-gateway
-spec:
-  type: NodePort
-  ports:
-    - name: http
-      port: 80
-      targetPort: 10080
-      nodePort: 30080
-    - name: https
-      port: 443
-      targetPort: 10443
-      nodePort: 30443
-  selector:
-    app.kubernetes.io/component: proxy

--- a/src/addons/envoy-gateway/custom.yaml
+++ b/src/addons/envoy-gateway/custom.yaml
@@ -65,7 +65,7 @@ metadata:
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
   parametersRef:
-    group: config.gateway.envoyproxy.io
+    group: gateway.envoyproxy.io
     kind: EnvoyProxy
     name: host-port-config
     namespace: envoy-gateway

--- a/src/addons/envoy-gateway/custom.yaml
+++ b/src/addons/envoy-gateway/custom.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: config.gateway.envoyproxy.io/v1alpha1
+apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
   name: host-port-config
@@ -8,39 +8,55 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      useListenerPortAsContainerPort: true
       envoyDeployment:
         replicas: 1 # Scale based on available control plane nodes
         container:
-          ports:
-          - name: http
-            containerPort: 8080
-            hostPort: 80 # Binds to Node Public IP port 80
-          - name: https
-            containerPort: 8443
-            hostPort: 443 # Binds to Node Public IP port 443
-          # Needed if using ports < 1024 on some K8s distributions
           securityContext:
-            capabilities:
-              add: ["NET_BIND_SERVICE"]
-        pod:
-          nodeSelector:
-            node-role.kubernetes.io/control-plane: "true"
-          tolerations:
-          - key: node-role.kubernetes.io/control-plane
-            operator: Exists
-            effect: NoSchedule
-          - key: node-role.kubernetes.io/master
-            operator: Exists
-            effect: NoSchedule
-          # REQUIRED: Prevents 2 pods from landing on 1 node (Port Conflict)
-          affinity:
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchLabels:
-                    # Matches the label Envoy Gateway adds to its managed proxy pods
-                    gateway.envoyproxy.io/owning-gateway-name: public-gateway
-                topologyKey: "kubernetes.io/hostname"
+            allowPrivilegeEscalation: true
+            runAsUser: 0
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  hostNetwork: true
+                  dnsPolicy: ClusterFirstWithHostNet
+                  containers:
+                  - name: envoy
+                    ports:
+                    - name: http
+                      containerPort: 80
+                      hostPort: 80 # Binds to Node Public IP port 80
+                      protocol: TCP
+                    - name: https
+                      containerPort: 443
+                      hostPort: 443 # Binds to Node Public IP port 443
+                      protocol: TCP
+                    # Needed if using ports < 1024 on some K8s distributions
+                    securityContext:
+                      capabilities:
+                        add: ["NET_BIND_SERVICE"]
+                  nodeSelector:
+                    # Matches the label added by kubeadm to control plane nodes
+                    node-role.kubernetes.io/control-plane: ""
+                  tolerations:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                    effect: NoSchedule
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                    effect: NoSchedule
+                  # REQUIRED: Prevents 2 pods from landing on 1 node (Port Conflict)
+                  affinity:
+                    podAntiAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                      - labelSelector:
+                          matchLabels:
+                            # Matches the label Envoy Gateway adds to its managed proxy pods
+                            gateway.envoyproxy.io/owning-gateway-name: envoy-gateway
+                        topologyKey: "kubernetes.io/hostname"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
@@ -61,6 +77,9 @@ metadata:
   namespace: envoy-gateway
 spec:
   gatewayClassName: envoy-gateway
+  addresses:
+  - type: Hostname
+    value: clusterx.qedzone.ro
   listeners:
     - name: http
       port: 80

--- a/src/addons/envoy-gateway/custom.yaml
+++ b/src/addons/envoy-gateway/custom.yaml
@@ -57,6 +57,8 @@ spec:
                             # Matches the label Envoy Gateway adds to its managed proxy pods
                             gateway.envoyproxy.io/owning-gateway-name: envoy-gateway
                         topologyKey: "kubernetes.io/hostname"
+      envoyService:
+        type: ClusterIP
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/src/bootstrap/control-plane.sh
+++ b/src/bootstrap/control-plane.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
- 
+
 # Setup and bootstrap k8s control-plane components
 
 set -xe

--- a/src/bootstrap/kubeadm/control-plane.yaml
+++ b/src/bootstrap/kubeadm/control-plane.yaml
@@ -10,6 +10,8 @@ localAPIEndpoint:
   bindPort: 6443
 nodeRegistration:
   criSocket: "unix:///var/run/crio/crio.sock"
+  kubeletExtraArgs:
+    node-labels: "node-role.kubernetes.io/control-plane=true"
   taints:
     - key: node-role.kubernetes.io/control-plane
       effect: NoSchedule

--- a/src/bootstrap/kubeadm/control-plane.yaml
+++ b/src/bootstrap/kubeadm/control-plane.yaml
@@ -10,8 +10,6 @@ localAPIEndpoint:
   bindPort: 6443
 nodeRegistration:
   criSocket: "unix:///var/run/crio/crio.sock"
-  kubeletExtraArgs:
-    node-labels: "node-role.kubernetes.io/control-plane=true"
   taints:
     - key: node-role.kubernetes.io/control-plane
       effect: NoSchedule


### PR DESCRIPTION
This change will allow us to expose the gateway directly over 80 and 443 ports without the hassle of using a node port like 30443.

The only limitation with this approach is that the envoy pods will run on control plane nodes.

/hold
Needs to be tested first.